### PR TITLE
Update main screen template

### DIFF
--- a/content/single-module-application/src/main/java/${project_rootPath}/screen/main/MainScreen.java
+++ b/content/single-module-application/src/main/java/${project_rootPath}/screen/main/MainScreen.java
@@ -13,9 +13,23 @@ public class MainScreen extends Screen implements Window.HasWorkArea {
 
     @Autowired
     private AppWorkArea workArea;
+    @Autowired
+    private Drawer drawer;
+    @Autowired
+    private Button collapseDrawerButton;
 
     @Override
     public AppWorkArea getWorkArea() {
         return workArea;
+    }
+
+    @Subscribe("collapseDrawerButton")
+    private void onCollapseDrawerButtonClick(Button.ClickEvent event) {
+        drawer.toggle();
+        if (drawer.isCollapsed()) {
+            collapseDrawerButton.setIconFromSet(JmixIcon.CHEVRON_RIGHT);
+        } else {
+            collapseDrawerButton.setIconFromSet(JmixIcon.CHEVRON_LEFT);
+        }
     }
 }

--- a/content/single-module-application/src/main/resources/${project_rootPath}/screen/main/main-screen.xml
+++ b/content/single-module-application/src/main/resources/${project_rootPath}/screen/main/main-screen.xml
@@ -3,41 +3,39 @@
 
     <layout>
         <cssLayout id="horizontalWrap"
-                   stylename="c-sidemenu-layout"
-                   height="100%"
-                   width="100%">
-            <cssLayout id="sideMenuContainer"
-                       height="100%"
-                       stylename="c-sidemenu-container">
-                <cssLayout id="sideMenuPanel"
-                           stylename="c-sidemenu-panel">
-                    <cssLayout id="appTitleBox"
-                               stylename="c-sidemenu-title"
-                               width="100%">
-                        <image id="logoImage"
-                               stylename="c-app-icon"
-                               scaleMode="SCALE_DOWN">
-                            <theme path="branding/app-icon-menu.svg"/>
-                        </image>
-                        <label id="appTitleLabel"
-                               stylename="c-app-title"
-                               value="msg://application.logoLabel"/>
-                    </cssLayout>
-                    <sideMenu id="sideMenu"
-                              width="100%"/>
-                    <timeZoneIndicator id="timeZoneIndicator"
-                                       align="MIDDLE_CENTER"/>
-                    <cssLayout id="controlBox"
-                               stylename="c-sidemenu-controls"
-                               width="100%">
-                        <userIndicator id="userIndicator"
-                                       align="MIDDLE_CENTER"/>
-                        <logoutButton id="logoutButton"
-                                      icon="SIGN_OUT"
-                                      description="msg://logoutBtnDescription"/>
-                    </cssLayout>
+                   stylename="jmix-drawer-layout">
+            <drawer id="drawer" expandOnHover="true">
+                <cssLayout id="appTitleBox"
+                           stylename="jmix-drawer-header"
+                           width="100%">
+                    <image id="logoImage"
+                           stylename="app-icon"
+                           scaleMode="SCALE_DOWN">
+                        <theme path="branding/app-icon-menu.svg"/>
+                    </image>
+                    <label id="appTitleLabel"
+                           stylename="app-title"
+                           value="msg://application.logoLabel"/>
                 </cssLayout>
-            </cssLayout>
+                <sideMenu id="sideMenu"
+                          width="100%"
+                          stylename="jmix-drawer-content"/>
+                <timeZoneIndicator id="timeZoneIndicator"
+                                   align="MIDDLE_CENTER"/>
+                <cssLayout id="controlBox"
+                           stylename="jmix-drawer-footer"
+                           width="100%">
+                    <button id="collapseDrawerButton"
+                            icon="CHEVRON_LEFT"
+                            stylename="jmix-drawer-collapse-button"
+                            description="mainMsg://sideMenuCollapse"/>
+                    <userIndicator id="userIndicator"
+                                   align="MIDDLE_CENTER"/>
+                    <logoutButton id="logoutButton"
+                                  icon="SIGN_OUT"
+                                  description="msg://logoutBtnDescription"/>
+                </cssLayout>
+            </drawer>
             <workArea id="workArea"
                       stylename="c-workarea"
                       height="100%">


### PR DESCRIPTION
Fix for #7 

`SideMenu` with `Drawer` is used as the default **Main Screen** template.