### PR TITLE
Introduced template.json for project templates

### DIFF
--- a/content/project/single-module-addon/template.description
+++ b/content/project/single-module-addon/template.description
@@ -1,1 +1,0 @@
-<html>Template of Jmix add-on. The add-on includes a sample entity, its UI screens and integration tests.</html>

--- a/content/project/single-module-addon/template.json
+++ b/content/project/single-module-addon/template.json
@@ -1,0 +1,5 @@
+{
+  "name": "Single Module Add-On",
+  "order": 1,
+  "description": "<html>Template of Jmix add-on. The add-on includes a sample entity, its UI screens and integration tests.</html>"
+}

--- a/content/project/single-module-application/template.description
+++ b/content/project/single-module-application/template.description
@@ -1,1 +1,0 @@
-<html>Template of single module <i>Jmix</i> application.</html>

--- a/content/project/single-module-application/template.json
+++ b/content/project/single-module-application/template.json
@@ -1,0 +1,11 @@
+{
+  "name": "Single Module Application",
+  "order": 0,
+  "description": "<html>Template of single module Jmix application.</html>",
+  "params": [
+    {
+      "name": "projectId",
+      "mandatory": false
+    }
+  ]
+}

--- a/content/project/theme-addon/template.description
+++ b/content/project/theme-addon/template.description
@@ -1,1 +1,0 @@
-<html>Template of a theme add-on. Theme add-on may provide SCSS files for a theme compilation.</html>

--- a/content/project/theme-addon/template.json
+++ b/content/project/theme-addon/template.json
@@ -1,0 +1,5 @@
+{
+  "name": "Theme Add-On",
+  "order": 2,
+  "description": "<html>Template of a theme add-on. Theme add-on may provide SCSS files for a theme compilation.</html>"
+}

--- a/content/project/widgets-addon/template.description
+++ b/content/project/widgets-addon/template.description
@@ -1,1 +1,0 @@
-<html>Template of a widgets add-on. Widgets add-on may provide UI components inherited from Vaadin components as well as their Jmix wrappers.</html>

--- a/content/project/widgets-addon/template.json
+++ b/content/project/widgets-addon/template.json
@@ -1,0 +1,5 @@
+{
+  "name": "Theme Add-On",
+  "order": 3,
+  "description": "<html>Template of a widgets add-on. Widgets add-on may provide UI components inherited from Vaadin components as well as their Jmix wrappers.</html>"
+}


### PR DESCRIPTION
Introduced `template.jmix` containing additional template metadata required for https://youtrack.haulmont.com/issue/JST-1559 and https://youtrack.haulmont.com/issue/JST-1562.
Also removed `template.description` file, the description is now specified in `template.json`. 